### PR TITLE
ISSUE-2: Add regions so blocks are not hardcoded (and change the CSS/targeting)

### DIFF
--- a/css/page--front.css
+++ b/css/page--front.css
@@ -81,14 +81,14 @@
     padding-left: 35px;
 }
 
-#frontpage-toolkit .card-body .field p:last-child {
+#frontpage-toolkit .card-body p:last-child {
     text-align: right;
     text-decoration: underline;
 }
 
 /* Explore cards */
 
-/* Corner triangle */
+/* Corner triangle for explore cards */
 #explore > div::before,
 #explore > div::after {
     content: '';
@@ -114,27 +114,24 @@
 
 #explore {
     margin-top: 2rem;
-    /* Why hardcode 42px? To match opposite of 58px for #navbar-main in navbar.css ... */
-    margin-left: -42px;
     overflow: hidden;
     background-color: rgba(191, 213, 193, 1);
+    padding: 30px 15px;
+
 }
 
-@media (min-width: 1201px) {
+@media (min-width: 992px) {
     #explore {
-        padding: 60px 120px;
+        /* Why hardcode 42px? To match opposite of 58px for #navbar-main in navbar.css ... */
+        margin-left: -42px;
     }
 }
+
 @media (min-width: 993px) {
     #explore {
-        padding: 60px 60px;
+        padding: 60px 60px 30px 60px;
         /* Why hardcode 100px? To match navbar.css ... */
         margin-right: -100px;
-    }
-}
-@media (min-width: 577px) {
-    #explore {
-        margin-left:0;
     }
 }
 
@@ -143,6 +140,12 @@
     overflow: hidden;
     background-clip: content-box;
     border-radius: 25px;
+}
+
+@media (max-width: 768px) {
+    #explore > div {
+        margin: 10px 5px;
+    }
 }
 
 #explore > div p {
@@ -165,18 +168,19 @@
     float: right;
 }
 
-/* Featured Panorama */
-.featured-panorama h1 {
-    padding-left: 30px;
-    margin-top: 0;
-}
+/*.featured-panorama h1 {*/
+/*    padding-left: 30px;*/
+/*    margin-top: 0;*/
+/*}*/
 
-@media (max-width: 993px) {
-    .featured-panorama h1 {
-        margin: 1rem 0;
-        padding-left: 0;
-    }
-}
+/*@media (max-width: 992px) {*/
+/*    .featured-panorama h1 {*/
+/*        margin: 1rem 0;*/
+/*        padding-left: 0;*/
+/*    }*/
+/*}!* Featured Panorama *!*/
+
+
 
 .featured-panorama #featured-panorama-icon {
     z-index: 1;
@@ -187,6 +191,23 @@
     background: url('../img/street-view-solid.png');
 }
 
+/*This is the title that says "\\ Featuerd Panorama" */
+.featured-panorama .views-element-container > h2  {
+    margin-top: 2rem;
+}
+
+@media (min-width: 576px) {
+    .featured-panorama .views-element-container > h2  {
+        margin-left: 30px;
+        margin-top: 0;
+    }
+}
+
+.featured-panorama .views-element-container > h2:before {
+    content: "\005C\005C";
+}
+
+/*This is the title overlay on top of viewer*/
 .view-featured-panorama .views-field-title {
     z-index: 1;
     position: absolute;
@@ -202,7 +223,17 @@
     text-decoration: none;
 }
 
-/* Info paragraphs */
-#front-feature #info {
-    margin-top: 2rem
+.featured-panorama .views-element-container .view-content {
+    margin: 0 !important;
+}
+@media (min-width: 576px) {
+    .featured-panorama .views-element-container .view-content {
+       max-width: 100%;
+    }  
+}
+
+/* Info paragraphs aka 'featured_last_row' region */
+
+.region-featured-last {
+    margin: 3rem 0 1rem 0;
 }

--- a/esie_subtheme.info.yml
+++ b/esie_subtheme.info.yml
@@ -24,6 +24,10 @@ regions:
   highlighted: Highlighted
   featured_top: 'Featured top'
   breadcrumb: Breadcrumb
+  featured_second_top_left: 'Featured Second Row, Left Colum'
+  featured_second_top_right: 'Featured Second Row, Right Colum'
+  featured_middle: 'Featured Middle Row'
+  featured_last: 'Featured Last Row'
   content: Content
   sidebar_first: 'Sidebar first'
   sidebar_second: 'Sidebar second'

--- a/esie_subtheme.theme
+++ b/esie_subtheme.theme
@@ -87,3 +87,49 @@ function esie_subtheme_theme_suggestions_node_edit_form_alter(array &$suggestion
     $suggestions[] = 'node_edit_form__contributor';
   }
 }
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for region templates.
+ * @param array $suggestions
+ * @param array $variables
+ */
+function esie_subtheme_theme_suggestions_region_alter(array &$suggestions, array $variables) {
+  $nowrap = [
+    //  featured_second_top_right holds the the stacked Welcome and Toolkit blocks on the front page
+    'featured_second_top_left',
+    //  featured_second_top_right holds the Featured Panorama block on the front page
+    'featured_second_top_right',
+    //  featured_middle holds the explore cards
+    'featured_middle'
+  ];
+  if ( theme_get_setting('bootstrap_barrio_region_clean_' . $variables['elements']['#region']) !== NULL) {
+    $region_clean = theme_get_setting('bootstrap_barrio_region_clean_' . $variables['elements']['#region']);
+  }
+  else {
+    $region_clean = in_array($variables['elements']['#region'], $nowrap);
+  }
+  if ( $region_clean ) {
+    $suggestions[] = 'region__nowrap';
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for block.html.twig.
+ *  @param array $variables
+ */
+function esie_subtheme_preprocess_block(&$variables) {
+  $block_id = $variables['elements']['#id'];
+  $block = \Drupal\block\Entity\Block::load($block_id);
+//  $variables['region'] = $block->getRegion();
+//  error_log(var_export($block->getRegion(), true));
+  $region = $block->getRegion();
+  // Adds col-md-4 class to the featured_middle region, i.e. the region holding the "Explore By" Cards.
+  if ($region == 'featured_middle') {
+    error_log(var_export($block->getRegion(), true));
+    $variables['attributes']['class'][] = 'col-md-4';
+  }
+  if ($region == 'featured_last') {
+    error_log(var_export($block->getRegion(), true));
+    $variables['attributes']['class'][] = 'col-md-6';
+  }
+}

--- a/templates/includes/page-content.html.twig
+++ b/templates/includes/page-content.html.twig
@@ -1,7 +1,7 @@
 <div id="main" class="{{ container }}">
     {{ page.breadcrumb }}
     <div class="row row-offcanvas row-offcanvas-left clearfix">
-        <main{{ content_attributes }}{{content_attributes.addClass('col-lg-9').removeClass('col')}}>
+        <main{{ content_attributes }}{{content_attributes.addClass('d-flex col-lg-9').removeClass('col')}}>
             <section class="section">
                 <a id="main-content" tabindex="-1"></a>
                 {{ page.content }}

--- a/templates/page--front.html.twig
+++ b/templates/page--front.html.twig
@@ -1,4 +1,3 @@
-
 {#
 /**
  * @file
@@ -43,6 +42,9 @@
  * - page.primary_menu: Items for the primary menu region.
  * - page.secondary_menu: Items for the secondary menu region.
  * - page.featured_top: Items for the featured top region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ * - page.featured_second_top_left: Items for the Second featured top left region.
+ * - page.featured_second_top_right: Items for the Second featured top right region.
  * - page.content: The main content of the current page.
  * - page.sidebar_first: Items for the first sidebar.
  * - page.sidebar_second: Items for the second sidebar.
@@ -54,7 +56,6 @@
  * - page.footer_third: Items for the third footer column.
  * - page.footer_fourth: Items for the fourth footer column.
  * - page.footer_fifth: Items for the fifth footer column.
- * - page.breadcrumb: Items for the breadcrumb region.
  *
  * Theme variables:
  * - navbar_top_attributes: Items for the header region.
@@ -86,44 +87,18 @@
     <div id="main" class="{{ container }}">
         {{ page.breadcrumb }}
         <div class="row" id="front-feature">
-            <div class="col-md-4">
-{#                 Doesn't work: #}
-{#                 {{ bamboo_render_block('frontpagewelcomemessage') } }#}
-{#                 Works with PLUGIN ID only, not block ID #}
-                <div class="card" id="frontpage-welcome">
-                    <div class="card-body">
-                        {{ bamboo_render_block('block_content:6bd4ad6b-8bdf-4dc4-8caf-0b5fb73c71df') }}
-                    </div>
-                </div>
-                <div class="card" id="frontpage-toolkit">
-                    <div class="card-body">
-                        {{ bamboo_render_block('block_content:ffdc2c33-1746-4e57-a0d5-d84d3071cdc4') }}
-                    </div>
-                </div>
+             <div class="col-md-4">
+                {{ page.featured_second_top_left }}
             </div>
             <div class="col-md-8 featured-panorama">
-                <h1 class="title">Featured Panorama</h1>
-               {{ bamboo_render_block('views_block:featured_panorama-block_1') }}
+                {{ page.featured_second_top_right }}
             </div>
         </div>
         <div class="row" id="explore">
-            <div class="col-sm-4">
-                {{ bamboo_render_block('block_content:9aad5f90-475e-4a92-91cb-6d88957a9ac5') }}
-            </div>
-            <div class="col-sm-4">
-                {{ bamboo_render_block('block_content:48f3ca56-4f55-44be-8d09-0833022b4249') }}
-            </div>
-            <div class="col-sm-4">
-                {{ bamboo_render_block('block_content:62e79764-0a57-4195-ba64-67181bc8c487') }}
-            </div>
+             {{ page.featured_middle }}
         </div>
         <div class="row" id="info">
-            <div class="col-sm-6">
-                {{ bamboo_render_block('block_content:e038cdd5-af63-4b50-a51f-c08bef6914a3') }}
-            </div>
-            <div class="col-sm-6">
-                {{ bamboo_render_block('block_content:e038cdd5-af63-4b50-a51f-c08bef6914a3') }}
-            </div>
+             {{ page.featured_last }}
         </div>
     </div>
 {% endblock %}

--- a/templates/page--front.html.twig
+++ b/templates/page--front.html.twig
@@ -45,6 +45,8 @@
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.featured_second_top_left: Items for the Second featured top left region.
  * - page.featured_second_top_right: Items for the Second featured top right region.
+ * - page.featured_middle: Items for the Featured Middle Row region.
+ * - page.featured_last: Items for Featured Last Row region.
  * - page.content: The main content of the current page.
  * - page.sidebar_first: Items for the first sidebar.
  * - page.sidebar_second: Items for the second sidebar.


### PR DESCRIPTION
This pull addresses #3 

### What is new?

This pull deals with the extra markup generated by moving content into regions, so we can target it with the CSS and the rest of the theme.

1. Made `featured_second_top_left`, `featured_second_top_right` and `featured_middle` nowrap regions (no extra markup added around them) - This pattern was copied from Barrio's .theme hooks.

2. Needed to add col-* classes to custom blocks within the regions. So added `esie_subtheme_preprocess_block` in our `esie_subtheme.theme` file.

3. Adjusted CSS.

4. Added `templates/layout/region--featured-second-top-right.html.twig` which is where Featured Panorama block lives. So that I could remove some of the containers around usual regions, to make the nice panorama image expand further wide across small screens. 