### PR TITLE
ISSUE-1: Adjust styles for webforms, pages, content listings

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -13,6 +13,15 @@ body {
 
 #main-wrapper {
     padding-bottom: 250px;
+    margin-left: 0;
+}
+
+@media (min-width: 993px) {
+    /* When not on front page, align w gray bar */
+    #main {
+        /* Why hardcode 58px? To match the edge if gray bar in navbar.css ... */
+        padding: 0 58px;
+    }
 }
 
 h1, h2, h3, h4, h5, h6, h1 a, h2 a, h3 a {
@@ -46,6 +55,36 @@ main .feed-icons {
     .highlighted {
         margin-left:250px;
     }
+}
+
+.views-header {
+    padding: 0 0 15px 15px;
+    color: rgba(80, 90, 90, 255);
+}
+
+/* These are the background colors behind the filters above content listings */
+#main .views-element-container .views-exposed-form {
+    padding: 15px;
+    background-color: rgba(0, 0, 0, 0.063);
+    -moz-border-radius: 8px;
+    -webkit-border-radius: 8px;
+    border-radius: 8px; /* future proofing */
+    -khtml-border-radius: 8px; /* for old Konqueror browsers */
+}
+
+#main .views-element-container #edit-header {
+    margin-top: 15px;
+    padding: 15px 0;
+    background-color: rgba(0, 0, 0, 0.063);
+    -moz-border-radius: 8px;
+    -webkit-border-radius: 8px;
+    border-radius: 8px; /* future proofing */
+    -khtml-border-radius: 8px; /* for old Konqueror browsers */
+}
+
+/* This is the "Apply to selected items" button in the filter area above content listings */
+#edit-submit--2 {
+    margin-left: 15px;
 }
 
 /* Content */
@@ -85,9 +124,6 @@ details summary {
 
 
 /*Explore Pages*/
-
-.explore-page .views-row {
-}
 
 .explore-page .views-row:not(:first-child) {
     padding: 2rem 0 0 0;

--- a/css/form.css
+++ b/css/form.css
@@ -1,10 +1,16 @@
+/*Border around main webform*/
+#edit-field-descriptive-metadata-wrapper {
+    border-bottom: 1px #656565 solid;
+}
 /* Node edit buttons */
 #edit-submit {
-    background-color: rgba(191, 213, 193, 1)
+    background-color: rgba(31, 111, 108, 137);
+    color: white;
 }
 #edit-preview {
     background-color: rgba(40, 167, 115, 0.3);
 }
+
 
 /*Custom node-edit forms, see templates/custom-edit/ */
 

--- a/css/form.css
+++ b/css/form.css
@@ -1,9 +1,9 @@
-/*Border around main webform*/
+/* Border under main webform */
 #edit-field-descriptive-metadata-wrapper {
     border-bottom: 1px #656565 solid;
 }
-/* Node edit buttons */
-#edit-submit {
+/* Buttons */
+#edit-submit, #edit-submit--2, .form-submit {
     background-color: rgba(31, 111, 108, 137);
     color: white;
 }
@@ -11,11 +11,21 @@
     background-color: rgba(40, 167, 115, 0.3);
 }
 
+#main .nav a:hover, #main .nav a:focus, #main .nav .link:hover, #main .nav .link:focus {
+    color: rgb(235, 141, 0);
+    text-decoration: underline;
+}
 
 /*Custom node-edit forms, see templates/custom-edit/ */
 
+/* "Object title" above descriptive metadata in Webform */
 .custom-edit-form .field--name-title {
-    padding-left: 0;
+    padding: 15px 0;
+    background-color: rgba(0, 0, 0, 0.063);
+    -moz-border-radius: 8px;
+    -webkit-border-radius: 8px;
+    border-radius: 8px; /* future proofing */
+    -khtml-border-radius: 8px; /* for old Konqueror browsers */
 }
 
 .custom-edit-form fieldset legend {
@@ -30,7 +40,6 @@
     /*increases visibility of gray on gray*/
     border: 1px solid #000;
 }
-
 
 /* Exposed Solr Search Form */
 
@@ -116,3 +125,18 @@
 .js fieldset.form-type-search-api-autocomplete input.form-autocomplete.ui-autocomplete-loading:focus {
     background-image: url(../../../../core/misc/throbber-active.gif);
 }
+
+/* This is the "Current state: Draft" etc. section below webforms */
+.entity-content-form-footer div, #edit-moderation-state-wrapper {
+    padding: 0 0 1px 0;
+    background-color: rgb(220, 220, 220);
+    -moz-border-radius: 8px;
+    -webkit-border-radius: 8px;
+    border-radius: 8px; /* future proofing */
+    -khtml-border-radius: 8px; /* for old Konqueror browsers */
+}
+
+.views-form div {
+    padding: 0;
+}
+

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -9,9 +9,50 @@ header > nav:first-child {
     background-position: 80% 0%;
 }
 
-#CollapsingNavbar > div:first-child {
-    display: flex;
-    justify-content: flex-end;
+
+@media (min-width: 993px) {
+    #CollapsingNavbar > div:first-child {
+        display: flex;
+        justify-content: flex-end;
+    }
+}
+
+/* Display all links within dropdowns as expanded on mobile */
+@media (max-width: 992px) {
+    .dropdown-toggle {
+        display: none;
+    }
+
+    .dropdown-menu {
+        display: block;
+        position: relative;
+        border-width: 0;
+        padding: 0;
+        margin: 0;
+        background-color: unset;
+        color: white;
+    }
+
+    .dropdown-item {
+        padding: .5rem 0rem;
+        color: rgba(0,0,0,.5);
+    }
+
+    .dropdown-item a {
+        color: white;
+    }
+    
+    .dropdown-item a:hover, .dropdown-item a:focus {
+        color: rgba(255, 255, 255, 0.75);
+        text-decoration: none;
+    }
+
+    .dropdown-item:hover, .dropdown-item:focus {
+        background-color: unset;
+        color: white;
+    }
+
+    
 }
 
 /* #navbar-main is defined as the wrapper id of the 2nd header in bootstrap_barrio.theme line 133*/

--- a/css/webform.css
+++ b/css/webform.css
@@ -50,15 +50,13 @@
     background-color: rgb(235, 141, 0);
 }
 
-.webform-actions .webform-button--next {
-    background-color: #bfd5c1;
+.webform-actions .webform-button--next, .webform-actions webform-button--submit {
+    background-color: rgba(31, 111, 108, 137);
+    color: white;
 }
 
-.webform-button--submit {
-    background-color: rgb(189, 213, 173);
-}
-
-.webform-button--preview {
+.webform-actions .webform-button--previous, .webform-actions .webform-button--reset {
+    /*border: 1px rgba(31, 111, 108, 137) solid;*/
     background-color: rgba(40, 167, 115, 0.3);
 }
 

--- a/css/webform.css
+++ b/css/webform.css
@@ -50,9 +50,13 @@
     background-color: rgb(235, 141, 0);
 }
 
-.webform-actions .webform-button--next, .webform-actions webform-button--submit {
+.webform-actions .webform-button--next, .webform-actions webform-button--submit, button[name="geographic_location_reconciliate_button"] {
     background-color: rgba(31, 111, 108, 137);
     color: white;
+}
+
+button[name="images_remove_button"] {
+    background-color: rgba(227, 173, 50, 173);
 }
 
 .webform-actions .webform-button--previous, .webform-actions .webform-button--reset {

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -1,0 +1,95 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ */
+#}
+
+
+{%
+    set classes = [
+    'js-form-item',
+    'js-form-type-' ~ type|clean_class,
+    type in ['checkbox', 'radio'] ? type|clean_class : 'form-type-' ~ type|clean_class,
+    type in ['checkbox', 'radio'] ? wrapperclass,
+    'js-form-item-' ~ name|clean_class,
+    'form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'disabled',
+    errors ? 'has-error',
+]
+%}
+{%
+    set description_classes = [
+    'description',
+    'text-muted',
+    description_display == 'invisible' ? 'sr-only',
+]
+%}
+{% if type in ['checkbox', 'radio'] %}
+    <div{{ attributes.addClass(classes) }}>
+        {% if prefix is not empty %}
+            <span class="field-prefix">{{ prefix }}</span>
+        {% endif %}
+        {% if description_display == 'before' and description.content %}
+            <div{{ description.attributes }}>
+                {{ description.content }}
+            </div>
+        {% endif %}
+        {% if label_display == 'before' %}
+            <label {{ attributes.addClass(labelclass).setAttribute('for', input_attributes.id) }}>
+                {{ input_title | raw }}
+            </label>
+        {% endif %}
+        <input{{ input_attributes.addClass(inputclass) }}>
+        {% if label_display == 'after' %}
+            <label {{ attributes.addClass(labelclass).setAttribute('for', input_attributes.id) }}>
+                {{ input_title | raw }}
+            </label>
+        {% endif %}
+        {% if suffix is not empty %}
+            <span class="field-suffix">{{ suffix }}</span>
+        {% endif %}
+        {% if errors %}
+            <div class="invalid-feedback">
+                {{ errors }}
+            </div>
+        {% endif %}
+        {% if description_display in ['after', 'invisible'] and description.content %}
+            <small{{ description.attributes.addClass(description_classes) }}>
+                {{ description.content }}
+            </small>
+        {% endif %}
+    </div>
+{% else %}
+    <fieldset{{ attributes.addClass(classes, 'form-group col') }}>
+        {% if label_display in ['before', 'invisible'] %}
+            {{ label }}
+        {% endif %}
+        {% if prefix is not empty %}
+            <span class="field-prefix">{{ prefix }}</span>
+        {% endif %}
+        {% if description_display == 'before' and description.content %}
+            <div{{ description.attributes }}>
+                {{ description.content }}
+            </div>
+        {% endif %}
+        {{ children }}
+        {% if suffix is not empty %}
+            <span class="field-suffix">{{ suffix }}</span>
+        {% endif %}
+        {% if label_display == 'after' %}
+            {{ label }}
+        {% endif %}
+        {% if errors %}
+            <div class="invalid-feedback">
+                {{ errors }}
+            </div>
+        {% endif %}
+        {% if description_display in ['after', 'invisible'] and description.content %}
+            <small{{ description.attributes.addClass(description_classes) }}>
+                {{ description.content }}
+            </small>
+        {% endif %}
+    </fieldset>
+{% endif %}

--- a/templates/form/input--submit-button.html.twig
+++ b/templates/form/input--submit-button.html.twig
@@ -12,4 +12,4 @@
  * @see template_preprocess_input()
  */
 #}
-<button{{ attributes }}>{{ attributes.value|raw }}</button>{{ children }}
+<button{{ attributes.removeClass('btn-sm') }}>{{ attributes.value|raw }}</button>{{ children }}

--- a/templates/views/views-view.html.twig
+++ b/templates/views/views-view.html.twig
@@ -62,7 +62,7 @@
   {% endif %}
 
   {% if rows %}
-    <div class="view-content row-bootstrap4 container">
+    <div class="view-content">
       {{ rows }}
     </div>
   {% elseif empty %}


### PR DESCRIPTION
Addresses #1 (General Styling issue)

What is new?

- Add border/divider below webform

- Make buttons bigger and stronger colors

- Align pages content to edge of gray top navbar

- Remove custom styles from radios and checkbox. This means default Bootstrap styles for now. Can customize at later time if desired.

- Add better style for pager results summary at top of list (class views-header) (this means yes, I enabled pagers thru the Drupal UI on server)

- Change highlight from white to orange on main content nav tabs

- Add darker gray background to Moderation State portion outside of webform, and also filters and form elements above content listings

- Make items inside dropdown nav menus expand automatically (aka not nest and remove dropdown header/category like "Create") when in mobile/hamburger menu

- Align filters above content listings

@DiegoPino 

(will address JS for admin toolbar in different pull)